### PR TITLE
View Agent can convert timestamps to local time

### DIFF
--- a/src/config.ini
+++ b/src/config.ini
@@ -8,9 +8,12 @@ gui_style = Go
 # https://services.swpc.noaa.gov/json/goes/primary/magnetometers-1-day.json
 data_types = differential-protons differential-electrons integral-protons integral-electrons magnetometers xrays
 # Options are 6-hour, 1-day, 3-day, and 7-day
-data_span = 3-day
+data_span = 7-day
 # Options are plotly, plotly_white, plotly_dark, ggplot2, seaborn, simple_white, none
 color_mode = plotly_white
+# Options are True or False
+# When True the x-axis is the local timezone, when False the x-axis is in UTC
+local_time_data = True
 [data]
 use_local = False
 local_raw = localData

--- a/src/data_agent_master.py
+++ b/src/data_agent_master.py
@@ -117,6 +117,7 @@ for thisDataSourceURL in allDataSourceURLs:
             dataDict["Hn"].append(float(dataPrecisionFormatter.format(thisElement["Hn"])))
             dataDict["Hp"].append(float(dataPrecisionFormatter.format(thisElement["Hp"])))
             dataDict["total"].append(float(dataPrecisionFormatter.format(thisElement["total"])))
+    ################
     # After the data has been formatted and appended, add the last_update string
     dataDict["last_update"] = timestamp.getTimestamp()
     ################

--- a/src/support/timestamp.py
+++ b/src/support/timestamp.py
@@ -1,7 +1,14 @@
 from datetime import datetime
+from dateutil import tz
 from tzlocal import get_localzone
 
 def getTimestamp():
     myLocalTimezone = get_localzone()
     myTimestamp = datetime.now(myLocalTimezone).strftime("%H:%M:%S %Z %Y-%m-%d")
     return myTimestamp
+
+def convertTimestamps(theseTimestamps):
+    newTimestamps = list()
+    for thisTimestamp in theseTimestamps:
+        newTimestamps.append(str(datetime.fromisoformat(thisTimestamp).astimezone(get_localzone())))
+    return newTimestamps

--- a/src/view_agent.py
+++ b/src/view_agent.py
@@ -1,5 +1,5 @@
 # This is the master view agent, it will display the local data files as graphs.
-from support import filehandling, colors
+from support import filehandling, timestamp, colors
 import configparser
 from dash import Dash, dcc, html, Input, Output
 import plotly.express as px
@@ -22,6 +22,7 @@ guiStyle        = config.get('view', 'gui_style')
 dataTypes       = config.get('view', 'data_types').split()
 dataSpan        = config.get('view', 'data_span')
 colorMode       = config.get('view', 'color_mode')
+localTimeData   = config.getboolean('view', 'local_time_data')
 
 templates = ("plotly", "plotly_white", "plotly_dark", "ggplot2", "seaborn", "simple_white", "none")
 
@@ -51,6 +52,10 @@ if guiStyle == "Go":
         ################
         # Store the Formatted Data
         dataDict = filehandling.getLocalData(localDataFolder=localFolder, localDataFilename=thisSourceFile)
+        ################
+        # Convert the time_tag array to the local time
+        if(localTimeData):
+            dataDict["time_tag"] = timestamp.convertTimestamps(theseTimestamps=dataDict["time_tag"])
         ################
         # Get the color family (only request colors for the keys which have data in them)
         thisColorSet = colors.getColorSet(len(dataDict["data_keys"]))


### PR DESCRIPTION
Based on a config.ini setting, the view agent can convert the data sample timestamps to local time. The data agent is still unaffected and stores the data from the server locally in UTC.