### PR TITLE
28 remove legend update annotation tooltip

### DIFF
--- a/src/view_agent.py
+++ b/src/view_agent.py
@@ -105,6 +105,9 @@ if guiStyle == "Go":
             row_index += 1
             if row_index == 4:
                 row_index = 1
+
+    # Disable the Legend as it is too cluttered being a single legend for all subplots
+    fig.update(layout_showlegend=False)
     
     # Show the figure...
     if showGui:

--- a/src/view_agent.py
+++ b/src/view_agent.py
@@ -108,6 +108,10 @@ if guiStyle == "Go":
 
     # Disable the Legend as it is too cluttered being a single legend for all subplots
     fig.update(layout_showlegend=False)
+
+    # Make the hover annotations legible
+    #fig.update_layout(hovermode="x unified") # This one adds "though bubbles" at each data point where the cursor is
+    fig.update_layout(hovermode="x unified") # This one adds a "floating legend" at the x position where the cursor is
     
     # Show the figure...
     if showGui:


### PR DESCRIPTION
Updates to the view agent are made to remove the graph legend and show a nice formatted annotation at the position of the cursor in each subplot.